### PR TITLE
Fixed Temperature ignoring decimal separator

### DIFF
--- a/OpenWeatherAPI/Coordinates.cs
+++ b/OpenWeatherAPI/Coordinates.cs
@@ -14,8 +14,8 @@ namespace OpenWeatherAPI
 			if (coordinateData is null)
 				throw new System.ArgumentNullException(nameof(coordinateData));
 
-			Longitude = double.Parse(coordinateData.SelectToken("lon").ToString(), CultureInfo.InvariantCulture);
-			Latitude = double.Parse(coordinateData.SelectToken("lat").ToString(), CultureInfo.InvariantCulture);
+			Longitude = double.Parse(coordinateData.SelectToken("lon").ToString(), CultureInfo.CurrentCulture);
+			Latitude = double.Parse(coordinateData.SelectToken("lat").ToString(), CultureInfo.CurrentCulture);
 		}
 	}
 }

--- a/OpenWeatherAPI/Main.cs
+++ b/OpenWeatherAPI/Main.cs
@@ -21,16 +21,16 @@ namespace OpenWeatherAPI
 				throw new System.ArgumentNullException(nameof(mainData));
 
 			Temperature = new TemperatureObj(
-								double.Parse(mainData.SelectToken("temp").ToString(), CultureInfo.InvariantCulture),
-								double.Parse(mainData.SelectToken("temp_min").ToString(), CultureInfo.InvariantCulture),
-								double.Parse(mainData.SelectToken("temp_max").ToString(), CultureInfo.InvariantCulture));
+								double.Parse(mainData.SelectToken("temp").ToString(), CultureInfo.CurrentCulture),
+								double.Parse(mainData.SelectToken("temp_min").ToString(), CultureInfo.CurrentCulture),
+								double.Parse(mainData.SelectToken("temp_max").ToString(), CultureInfo.CurrentCulture));
 
-			Pressure = double.Parse(mainData.SelectToken("pressure").ToString(), CultureInfo.InvariantCulture);
-			Humidity = double.Parse(mainData.SelectToken("humidity").ToString(), CultureInfo.InvariantCulture);
+			Pressure = double.Parse(mainData.SelectToken("pressure").ToString(), CultureInfo.CurrentCulture);
+			Humidity = double.Parse(mainData.SelectToken("humidity").ToString(), CultureInfo.CurrentCulture);
 			if (mainData.SelectToken("sea_level") != null)
-				SeaLevelAtm = double.Parse(mainData.SelectToken("sea_level").ToString(), CultureInfo.InvariantCulture);
+				SeaLevelAtm = double.Parse(mainData.SelectToken("sea_level").ToString(), CultureInfo.CurrentCulture);
 			if (mainData.SelectToken("grnd_level") != null)
-				GroundLevelAtm = double.Parse(mainData.SelectToken("grnd_level").ToString(), CultureInfo.InvariantCulture);
+				GroundLevelAtm = double.Parse(mainData.SelectToken("grnd_level").ToString(), CultureInfo.CurrentCulture);
 		}
 	}
 }


### PR DESCRIPTION
# Fixes #20 
### Changes
- Changed from using InvariantCulture to using CurrentCulture
- Code now uses the region specific seperators instead of the default ones

### Notes
This is tested using the region settings of Germany and the USA on a Windows 11 machine.