### PR TITLE
Api update - Geocode API

### DIFF
--- a/OpenWeatherAPI.Tests/APITests.cs
+++ b/OpenWeatherAPI.Tests/APITests.cs
@@ -1,6 +1,7 @@
+using System.Threading.Tasks;
 using Newtonsoft.Json;
-using System.Diagnostics;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace OpenWeatherAPI.Tests
 {
@@ -9,19 +10,73 @@ namespace OpenWeatherAPI.Tests
 	/// </summary>
 	public class APITests
 	{
-		[Fact()]
-		public void QueryTest_Success()
+		private const string apiKey = "API key goes here"; //No good solution here to have safe and valid OpenWeather API keys in a test
+		private readonly ITestOutputHelper output;
+
+		public APITests(ITestOutputHelper output)
+		{
+			this.output = output;
+		}
+
+		[Fact]
+		public async Task QueryTest_Success()
 		{
 			//Arrange
-			var api = new OpenWeatherApiClient("YOURAPIKEYHERE"); //No good solution here to have safe and valid OpenWeather API keys in a test
+			var api = new OpenWeatherApiClient(apiKey);
 
 			//Act
-			var actual = api.Query("Rotterdam,NL");
+			var actual = await api.QueryAsync("Rotterdam,NL");
 
 			//Assert
 			Assert.True(actual.ValidRequest);
 
-			Trace.WriteLine(JsonConvert.SerializeObject(actual, Formatting.Indented));
+			output.WriteLine(JsonConvert.SerializeObject(actual, Formatting.Indented));
+		}
+
+		[Fact]
+		public async Task QueryTestHttps_Success()
+		{
+			//Arrange
+			var api = new OpenWeatherApiClient(apiKey, true);
+
+			//Act
+			var actual = await api.QueryAsync("Rotterdam,NL");
+
+			//Assert
+			Assert.True(actual.ValidRequest);
+			Assert.True(actual.Main.Temperature.KelvinCurrent < 1000);
+
+			output.WriteLine(JsonConvert.SerializeObject(actual, Formatting.Indented));
+		}
+
+		[Fact]
+		public async Task Geolocate_Success()
+		{
+			//Arrange
+			var api = new OpenWeatherApiClient(apiKey);
+
+			//Act
+			var actual = await api.Geolocate("Rotterdam,NL");
+
+			//Assert
+			Assert.True(actual.ValidRequest);
+
+			output.WriteLine(JsonConvert.SerializeObject(actual, Formatting.Indented));
+		}
+
+		[Fact]
+		public async Task GeolocateHttps_Success()
+		{
+			//Arrange
+			var api = new OpenWeatherApiClient(apiKey, true);
+
+			//Act
+			var actual = await api.Geolocate("Rotterdam,NL");
+
+			//Assert
+			Assert.True(actual.ValidRequest);
+
+			output.WriteLine(JsonConvert.SerializeObject(actual, Formatting.Indented));
 		}
 	}
 }

--- a/OpenWeatherAPI/GeoResponse.cs
+++ b/OpenWeatherAPI/GeoResponse.cs
@@ -1,0 +1,20 @@
+﻿using System.Globalization;
+using Newtonsoft.Json.Linq;
+
+namespace OpenWeatherAPI
+{
+	public class GeoResponse
+	{
+		public bool ValidRequest { get; }
+		public double Lat { get; }
+		public double Lon { get; }
+
+		public GeoResponse(string jsonResponse)
+		{
+			var jsonData = JArray.Parse(jsonResponse);
+			Lat = double.Parse(jsonData[0].SelectToken("lat").ToString(), CultureInfo.CurrentCulture);
+			Lon = double.Parse(jsonData[0].SelectToken("lon").ToString(), CultureInfo.CurrentCulture);
+			ValidRequest = true;
+		}
+	}
+}

--- a/OpenWeatherAPI/OpenWeatherApiClient.cs
+++ b/OpenWeatherAPI/OpenWeatherApiClient.cs
@@ -20,24 +20,23 @@ namespace OpenWeatherAPI
 		{
 			var geo = await Geolocate(queryString).ConfigureAwait(false);
 
-			return new Uri($"http://api.openweathermap.org/data/2.5/weather?appid={_apiKey}&lat={geo.Lat}&lon={geo.Lon}");
+			string scheme = "http";
+			if (_useHttps)
+				scheme = "https";
+			return new Uri($"{scheme}://api.openweathermap.org/data/2.5/weather?appid={_apiKey}&lat={geo.Lat}&lon={geo.Lon}");
 		}
 
 		public async Task<GeoResponse> Geolocate(string queryString)
-		{
-			var jsonResponse = await _httpClient
-				.GetStringAsync(
-					new Uri($"http://api.openweathermap.org/geo/1.0/direct?q={queryString}&limit={1}&appid={_apiKey}"))
-				.ConfigureAwait(false);
-			return new GeoResponse(jsonResponse);
-		}
-		private Uri GenerateRequestUrl(string queryString)
 		{
 			string scheme = "http";
 			if (_useHttps)
 				scheme = "https";
 
-			return new Uri($"{scheme}://api.openweathermap.org/data/2.5/weather?appid={_apiKey}&q={queryString}");
+			var jsonResponse = await _httpClient
+				.GetStringAsync(
+					new Uri($"{scheme}://api.openweathermap.org/geo/1.0/direct?q={queryString}&limit={1}&appid={_apiKey}"))
+				.ConfigureAwait(false);
+			return new GeoResponse(jsonResponse);
 		}
 
 		/// <summary>

--- a/OpenWeatherAPI/OpenWeatherApiClient.cs
+++ b/OpenWeatherAPI/OpenWeatherApiClient.cs
@@ -16,6 +16,21 @@ namespace OpenWeatherAPI
 			_useHttps = useHttps;
 		}
 
+		private async Task<Uri> GenerateRequestUrl(string queryString)
+		{
+			var geo = await Geolocate(queryString).ConfigureAwait(false);
+
+			return new Uri($"http://api.openweathermap.org/data/2.5/weather?appid={_apiKey}&lat={geo.Lat}&lon={geo.Lon}");
+		}
+
+		public async Task<GeoResponse> Geolocate(string queryString)
+		{
+			var jsonResponse = await _httpClient
+				.GetStringAsync(
+					new Uri($"http://api.openweathermap.org/geo/1.0/direct?q={queryString}&limit={1}&appid={_apiKey}"))
+				.ConfigureAwait(false);
+			return new GeoResponse(jsonResponse);
+		}
 		private Uri GenerateRequestUrl(string queryString)
 		{
 			string scheme = "http";
@@ -32,7 +47,7 @@ namespace OpenWeatherAPI
 		/// <returns>Returns null if the query is invalid.</returns>
 		public async Task<QueryResponse> QueryAsync(string queryString)
 		{
-			var jsonResponse = await _httpClient.GetStringAsync(GenerateRequestUrl(queryString)).ConfigureAwait(false);
+			var jsonResponse = await _httpClient.GetStringAsync(GenerateRequestUrl(queryString).Result).ConfigureAwait(false);
 			var query = new QueryResponse(jsonResponse);
 			return query.ValidRequest ? query : null;
 		}


### PR DESCRIPTION
# Switch to using geocode API for location search
There is a new [geocode API](https://openweathermap.org/api/geocoding-api), that is recommended by OpenWeatherMap, as the [built-in geocoder](https://openweathermap.org/current#geocoding) is deprecated.

### Changes
- Added new geocode API (5612ac092e86daf1661d82e4adc937d31b12c78d)
- Integrated changes from swiftyspiffy/OpenWeatherMap-API-CSharp/master (87af8014cca415b2d8b33ff6ea4a147fcbca03a6)
    - Fixed integration problems (830b2e1c4e2f173954241ffdee28285da16786de, c0672bae9cfceafd10b0ad0900097d6500426621)
- Updated Unit Tests to use new functions (7f476ec398b39d3616eac93c4090d1fc12238e8d)
    - Also switched from using Trace.WriteLine to ITestOutputHelper to fix output not being shown